### PR TITLE
fix(deps): pin clibuilder to ~6.5.1 in the packages that publish it

### DIFF
--- a/.changeset/spotty-clouds-repeat.md
+++ b/.changeset/spotty-clouds-repeat.md
@@ -1,0 +1,17 @@
+---
+'@unional/monorepo-scripts': patch
+'@unional/devpkg-node': patch
+---
+
+Narrow the `clibuilder` dependency from `^6.5.1` to `~6.5.1`.
+
+Both packages call `createCli` from clibuilder, and clibuilder 6.6.1 removed that
+export — its `lib/index.d.ts` re-exports only `./errors` and `./parseArgv`, where
+6.5.1 also exported `./create-cli`, `./create-plugin-cli` and `./presenter`. Under
+the old caret range a fresh consumer install resolved 6.6.1 and the CLI threw at
+startup.
+
+The repository was not affected because a `pnpm-workspace.yaml` override pinned
+6.5.1 locally, which is exactly why this went unnoticed: an override binds this
+workspace only and never travels with the published package. The constraint now
+lives in each package's own `dependencies`, and the redundant override is removed.

--- a/packages/create-monorepo/package.json
+++ b/packages/create-monorepo/package.json
@@ -45,7 +45,7 @@
 	"dependencies": {
 		"@unional/createutils": "workspace:^",
 		"chalk": "^4.1.0",
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"iso-error": "^3.2.5",
 		"update-notifier": "^5.1.0",
 		"validate-npm-package-name": "^3.0.0"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"@unional/createutils": "workspace:^",
 		"chalk": "^4.1.0",
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"find-installed-packages": "^2.1.6",
 		"iso-error": "^3.2.5",
 		"ncp": "^2.0.0",

--- a/packages/createutils/package.json
+++ b/packages/createutils/package.json
@@ -32,6 +32,6 @@
 		"validate-npm-package-name": "^3.0.0"
 	},
 	"devDependencies": {
-		"clibuilder": "^6.5.1"
+		"clibuilder": "~6.5.1"
 	}
 }

--- a/packages/dev-scripts/package.json
+++ b/packages/dev-scripts/package.json
@@ -18,7 +18,7 @@
 		"clean": "rimraf .ts coverage lib libm"
 	},
 	"dependencies": {
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"update-notifier": "^5.1.0",
 		"chalk": "^4.1.0",
 		"find-installed-packages": "^2.1.6"

--- a/packages/devpkg-node/package.json
+++ b/packages/devpkg-node/package.json
@@ -38,7 +38,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"babel-jest": "^26.6.3",
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"dependency-check": "^4.1.0",
 		"eslint": "^7.19.0",
 		"eslint-plugin-harmony": "^5.0.1",

--- a/packages/monorepo-scripts/package.json
+++ b/packages/monorepo-scripts/package.json
@@ -50,7 +50,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"assertron": "^7.1.3",
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"commitlint-circle": "^1.0.0",
 		"dependency-check": "^4.1.0",
 		"eslint": "^7.19.0",

--- a/packages/singlerepo-scripts/package.json
+++ b/packages/singlerepo-scripts/package.json
@@ -47,7 +47,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"assertron": "^7.1.3",
-		"clibuilder": "^6.5.1",
+		"clibuilder": "~6.5.1",
 		"commitlint-circle": "^1.0.0",
 		"dependency-check": "^4.1.0",
 		"eslint": "^7.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ overrides:
   '@types/ramda': 0.27.38
   '@types/update-notifier': 5.0.0
   ansi-colors: 4.1.1
-  clibuilder: 6.5.1
   configstore: 5.0.1
   find-installed-packages: 2.1.6
   iso-error: 3.2.5
@@ -76,7 +75,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       find-installed-packages:
         specifier: 2.1.6
@@ -119,7 +118,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       iso-error:
         specifier: 3.2.5
@@ -150,7 +149,7 @@ importers:
         version: 3.0.0
     devDependencies:
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
 
   packages/dev-scripts:
@@ -159,7 +158,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       find-installed-packages:
         specifier: 2.1.6
@@ -201,7 +200,7 @@ importers:
         specifier: ^26.6.3
         version: 26.6.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       dependency-check:
         specifier: ^4.1.0
@@ -279,7 +278,7 @@ importers:
         specifier: ^7.1.3
         version: 7.1.3
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       commitlint-circle:
         specifier: ^1.0.0
@@ -369,7 +368,7 @@ importers:
         specifier: ^7.1.3
         version: 7.1.3
       clibuilder:
-        specifier: 6.5.1
+        specifier: ~6.5.1
         version: 6.5.1
       commitlint-circle:
         specifier: ^1.0.0
@@ -9501,7 +9500,7 @@ snapshots:
   '@jest/console@26.6.2':
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       jest-message-util: 26.6.2
       jest-util: 26.6.2
@@ -9510,7 +9509,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -9523,7 +9522,7 @@ snapshots:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2(supports-color@8.1.1)
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       exit: 0.1.2
@@ -9560,7 +9559,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -9596,14 +9595,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 26.6.2
 
   '@jest/environment@27.5.1':
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 27.5.1
 
   '@jest/fake-timers@24.9.0(supports-color@8.1.1)':
@@ -9618,7 +9617,7 @@ snapshots:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -9627,7 +9626,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9682,7 +9681,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -9822,7 +9821,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       '@types/yargs': 15.0.20
       chalk: 4.1.2
 
@@ -9830,7 +9829,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
@@ -10888,7 +10887,7 @@ snapshots:
 
   '@octokit/types@2.16.2':
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   '@octokit/types@6.41.0':
     dependencies:
@@ -11054,11 +11053,11 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 6.0.0
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -11084,7 +11083,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   '@types/minimatch@3.0.5': {}
 
@@ -11118,7 +11117,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   '@types/stack-utils@1.0.1': {}
 
@@ -14279,7 +14278,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -14444,7 +14443,7 @@ snapshots:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 26.6.2
       jest-util: 26.6.2
       jsdom: 16.7.0(supports-color@8.1.1)
@@ -14459,7 +14458,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0(supports-color@8.1.1)
@@ -14474,7 +14473,7 @@ snapshots:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 26.6.2
       jest-util: 26.6.2
 
@@ -14483,7 +14482,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -14495,7 +14494,7 @@ snapshots:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.9
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -14515,7 +14514,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -14535,7 +14534,7 @@ snapshots:
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       co: 4.6.0
       expect: 26.6.2
@@ -14561,7 +14560,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -14652,12 +14651,12 @@ snapshots:
   jest-mock@26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
 
   jest-pnp-resolver@1.2.3(jest-resolve@26.6.2):
     optionalDependencies:
@@ -14721,7 +14720,7 @@ snapshots:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
@@ -14751,7 +14750,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1(supports-color@8.1.1)
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -14838,12 +14837,12 @@ snapshots:
 
   jest-serializer@26.6.2:
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       graceful-fs: 4.2.11
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       graceful-fs: 4.2.11
 
   jest-snapshot@26.6.2(supports-color@8.1.1):
@@ -14914,7 +14913,7 @@ snapshots:
   jest-util@26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -14923,7 +14922,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -15029,7 +15028,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 26.6.2
@@ -15039,7 +15038,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -15047,13 +15046,13 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 24.13.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,17 +21,17 @@ allowBuilds:
   nx: false
 
 # Restores exactly what the deleted `yarn.lock` had resolved. These are floating `^`
-# ranges in package.json that have drifted since the last release in 2021:
-#   clibuilder 6.6.1 dropped `PromptPresenter`, `createCli` and `createPluginCommand`
-#   @types/update-notifier 5.1.0 broke its own ConfigStore typing (TS2709)
-# Pinned here rather than by narrowing the published `dependencies` ranges, so the
-# packages' own metadata is unchanged by this release-plumbing PR. Lifting either pin
-# is toolchain work, not sweep work.
+# ranges in package.json that have drifted since the last release in 2021 — for
+# example @types/update-notifier 5.1.0 broke its own ConfigStore typing (TS2709).
+#
+# `clibuilder` used to be pinned here too. That was the wrong place: an override binds
+# this workspace only, so the published `^6.5.1` ranges still resolved to 6.6.1 for
+# consumers, where `createCli` no longer exists. The constraint now lives in each
+# package's own `dependencies` as `~6.5.1`.
 overrides:
   '@types/ramda': 0.27.38
   '@types/update-notifier': 5.0.0
   ansi-colors: 4.1.1
-  clibuilder: 6.5.1
   configstore: 5.0.1
   find-installed-packages: 2.1.6
   iso-error: 3.2.5


### PR DESCRIPTION
## The defect

`@unional/devpkg-node` and `@unional/monorepo-scripts` both do `import { createCli } from 'clibuilder'` and both declared `"clibuilder": "^6.5.1"`.

clibuilder **6.6.1 removed that export**:

| version | `lib/index.d.ts` re-exports |
|---|---|
| 6.5.1 | `./argv-parser/types`, `./create-cli`, `./errors`, `./create-plugin-cli`, `./presenter`, `./test-util` |
| 6.6.1 | `./errors`, `./parseArgv` |

So under `^6.5.1` a fresh consumer install resolves 6.6.1, and the published CLI throws at startup. `@unional/devpkg-node` has real consumers (`@unional/uni-cli`, `test-steps`, `jest-watch-suspend`), so this is the range that matters most in the repo.

## Why nobody noticed

`pnpm-workspace.yaml` carried an `overrides` entry pinning clibuilder to 6.5.1. **An override binds this workspace only and does not travel with the published package** — so every local install, every CI run and every `verify` saw a working 6.5.1, while consumers got 6.6.1. The workaround was hiding the bug it was working around.

The constraint now lives where it ships: `~6.5.1` in each package's own `dependencies`. The override is removed, and `pnpm-lock.yaml` still resolves 6.5.1 from the ranges alone.

Applied to the private packages too (`@unional/create`, `@unional/create-monorepo`, `@unional/dev-scripts`, `@unional/singlerepo-scripts`) so nothing re-acquires the bad range if one is ever published.

## Changeset

Patch for `@unional/devpkg-node` and `@unional/monorepo-scripts` — a runtime `dependencies` change. `@unional/createutils` only has clibuilder as a devDependency, so it gets no bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC