### PR TITLE
ci: give the release verify job an explicit permissions block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   code:
     uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@v2
+    permissions:
+      contents: read
     with:
       os: '["ubuntu-latest"]'
       skip-playwright: true


### PR DESCRIPTION
Clears the last open CodeQL alert on `main` (`actions/missing-workflow-permissions`). The `code` job in `release.yml` inherited the repository default of write; `publish-gate` and `release` already scope their own. A verify run only needs `contents: read`.

No changeset — CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC