### PR TITLE
fix: point repository metadata at unional/create

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 ## Published packages
 
-- [@unional/devpkg-node](https://github.com/cyberuni/create/tree/main/packages/devpkg-node): shared development dependencies and configuration for Node.js libraries.
-- [@unional/createutils](https://github.com/cyberuni/create/tree/main/packages/createutils): utilities shared by the `create` tools.
-- [@unional/monorepo-scripts](https://github.com/cyberuni/create/tree/main/packages/monorepo-scripts): scripts for a TypeScript monorepo.
+- [@unional/devpkg-node](https://github.com/unional/create/tree/main/packages/devpkg-node): shared development dependencies and configuration for Node.js libraries.
+- [@unional/createutils](https://github.com/unional/create/tree/main/packages/createutils): utilities shared by the `create` tools.
+- [@unional/monorepo-scripts](https://github.com/unional/create/tree/main/packages/monorepo-scripts): scripts for a TypeScript monorepo.
 
 ## Unpublished packages
 
@@ -24,7 +24,7 @@ These are `private: true`, and this repository does not release them. All but on
 
 [changesets-image]: https://img.shields.io/badge/maintained%20with-changesets-176de3.svg
 [changesets-url]: https://github.com/changesets/changesets
-[codecov-image]: https://codecov.io/gh/cyberuni/create/branch/main/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/cyberuni/create
-[github-action-image]: https://github.com/cyberuni/create/workflows/release/badge.svg
-[github-action-url]: https://github.com/cyberuni/create/actions
+[codecov-image]: https://codecov.io/gh/unional/create/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/unional/create
+[github-action-image]: https://github.com/unional/create/workflows/release/badge.svg
+[github-action-url]: https://github.com/unional/create/actions

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
 	"version": "0.0.0-development",
 	"private": true,
 	"description": "@unional repository creation and management tools",
-	"homepage": "https://github.com/cyberuni/create",
+	"homepage": "https://github.com/unional/create",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"author": {

--- a/packages/create-monorepo/package.json
+++ b/packages/create-monorepo/package.json
@@ -21,13 +21,13 @@
 		"travis",
 		"typescript"
 	],
-	"homepage": "https://github.com/cyberuni/create/tree/main/packages/create-monorepo",
+	"homepage": "https://github.com/unional/create/tree/main/packages/create-monorepo",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"files": [

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -18,13 +18,13 @@
 		"travis",
 		"typescript"
 	],
-	"homepage": "https://github.com/cyberuni/create/tree/main/packages/create",
+	"homepage": "https://github.com/unional/create/tree/main/packages/create",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"bin": {

--- a/packages/createutils/package.json
+++ b/packages/createutils/package.json
@@ -2,13 +2,13 @@
 	"name": "@unional/createutils",
 	"version": "1.1.4",
 	"description": "utilities for create projects",
-	"homepage": "https://github.com/cyberuni/create/tree/main/packages/createutils",
+	"homepage": "https://github.com/unional/create/tree/main/packages/createutils",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"files": [

--- a/packages/dev-scripts/package.json
+++ b/packages/dev-scripts/package.json
@@ -2,13 +2,13 @@
 	"name": "@unional/dev-scripts",
 	"version": "0.1.2",
 	"description": "Development scripts",
-	"homepage": "https://github.com/cyberuni/create",
+	"homepage": "https://github.com/unional/create",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"bin": {

--- a/packages/devpkg-node/package.json
+++ b/packages/devpkg-node/package.json
@@ -9,13 +9,13 @@
 		"nodejs",
 		"typescript"
 	],
-	"homepage": "https://github.com/cyberuni/create",
+	"homepage": "https://github.com/unional/create",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"bin": {

--- a/packages/monorepo-scripts/package.json
+++ b/packages/monorepo-scripts/package.json
@@ -21,13 +21,13 @@
 		"typescript",
 		"yarn"
 	],
-	"homepage": "https://github.com/cyberuni/create/tree/main/packages/monorepo-scripts",
+	"homepage": "https://github.com/unional/create/tree/main/packages/monorepo-scripts",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"files": [

--- a/packages/singlerepo-scripts/package.json
+++ b/packages/singlerepo-scripts/package.json
@@ -18,13 +18,13 @@
 		"travis",
 		"typescript"
 	],
-	"homepage": "https://github.com/cyberuni/create/tree/main/packages/singlerepo-scripts",
+	"homepage": "https://github.com/unional/create/tree/main/packages/singlerepo-scripts",
 	"bugs": {
-		"url": "https://github.com/cyberuni/create/issues"
+		"url": "https://github.com/unional/create/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/cyberuni/create.git"
+		"url": "https://github.com/unional/create.git"
 	},
 	"license": "MIT",
 	"files": [


### PR DESCRIPTION
The 2026-09-02 org transfer moved this repo but left `package.json` naming its old owner. **npm verifies the provenance bundle against `repository.url` at publish time**, so the next release fails with:

```
E422 Unprocessable Entity - PUT https://registry.npmjs.org/<pkg>
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/<old-owner>/<repo>.git",
expected to match "https://github.com/<new-owner>/<repo>" from provenance
```

## How this was found

`jest-watch-suspend`'s first post-transfer release run hit it. Its trusted publisher had already been re-registered correctly, so the error moved on from `E404` (wrong publisher) to `E422` (wrong metadata) — **a second fault hiding behind the first**. An audit then found every one of the 14 transferred repos carries the same stale URL.

Nothing warns you: the old GitHub path keeps resolving through the rename/transfer redirect, so the value looks valid right up until a publish verifies it against the OIDC claim.

## Scope

`package.json` metadata (`repository`, `bugs`, `homepage`) plus README links pointing at this repo's own old path.

**`CHANGELOG.md` is deliberately untouched** — those are historical release records and their commit/compare links still resolve through the redirect. Rewriting them would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz