### PR TITLE
chore: declare a supported Node range

### DIFF
--- a/.changeset/engines-node-floor.md
+++ b/.changeset/engines-node-floor.md
@@ -1,0 +1,9 @@
+---
+'@unional/createutils': patch
+---
+
+Declare a supported Node range: `^20.19.0 || ^22.13.0 || >=24`.
+
+Every version in that range has unflagged `require(esm)`, so a CommonJS consumer's
+`require()` of this now-ESM-only package resolves rather than throwing `ERR_REQUIRE_ESM`.
+Node 18 (EOL April 2025) and Node 20.0–20.18 are excluded because `require()` hard-fails there.

--- a/packages/createutils/package.json
+++ b/packages/createutils/package.json
@@ -36,5 +36,8 @@
 	},
 	"devDependencies": {
 		"clibuilder": "~6.5.1"
+	},
+	"engines": {
+		"node": "^20.19.0 || ^22.13.0 || >=24"
 	}
 }


### PR DESCRIPTION
Declares `engines.node` as `^20.19.0 || ^22.13.0 || >=24`.

## Why this range

These packages just went ESM-only. A CommonJS consumer can still `require()` them, but only on a Node with unflagged `require(esm)` — which landed in **20.19.0** and **22.12.0**. Below that, `require()` throws `ERR_REQUIRE_ESM` outright.

So this range is not a guess at what to support; it is exactly the set of versions where the CJS escape hatch actually works. Anything the range excludes is a version where consuming this package from CJS is impossible:

- **Node 18** — EOL April 2025, and no `require(esm)` at all.
- **Node 20.0–20.18** — `require()` hard-fails.

It matches what `eslint-plugin-harmony` already declares (itself borrowed from ESLint 10's own range), so the whole set of packages in this migration is now consistent.

## Note on what `engines` does and does not fix

This makes the constraint *declared* rather than *discovered*. npm warns rather than blocks by default, so it will not stop a Node 18 install — but it turns a confusing runtime `ERR_REQUIRE_ESM` into a legible install-time signal, and lets tooling that does enforce engines do the right thing.

`pnpm verify` green. Patch changeset included, which folds into the major already pending in the release PR rather than cutting a separate version.